### PR TITLE
Refactor markdown highlighting settings in config.toml

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -7,7 +7,5 @@ compile_sass = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 
-[markdown]
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
+[markdown.highlighting]
+theme = "dark-plus"


### PR DESCRIPTION
Moved markdown highlighting configuration to a new section.